### PR TITLE
Fixed: HD leaderboards sorting, event priorities and cancellations, s…

### DIFF
--- a/BuildBattleProCore/src/main/java/me/drawethree/buildbattle/hooks/BBHookWorldEdit.java
+++ b/BuildBattleProCore/src/main/java/me/drawethree/buildbattle/hooks/BBHookWorldEdit.java
@@ -24,13 +24,23 @@ public class BBHookWorldEdit extends BBHook {
     public void hook(BuildBattle buildBattle) {
         if (Bukkit.getPluginManager().isPluginEnabled(pluginName)) {
             String version = Bukkit.getPluginManager().getPlugin(pluginName).getDescription().getVersion();
+            String fullName = Bukkit.getPluginManager().getPlugin(pluginName).getDescription().getFullName();
 
-            if (version.startsWith("7")) {
+            boolean compatible = false;
+            String minVersion = "7";
+
+            if (fullName.contains("FastAsyncWorldEdit") && (version.startsWith("1.15") || version.startsWith("1.16"))) {
+                compatible = true;
+                minVersion = "1.15";
+            } else if (version.startsWith("7"))
+                compatible = true;
+
+            if (compatible) {
                 BuildBattle.getInstance().info("§aSuccessfully hooked into §e" + this.pluginName + " §aversion §e" + version);
                 this.enabled = true;
                 this.runHookAction(buildBattle);
             } else {
-                BuildBattle.getInstance().warning("§cThis version of WorldGuard is not supported!(§e" + version + "§c). Please use version §e7.0.0 §cand above.");
+                BuildBattle.getInstance().warning("§cThis version of " + fullName + " is not supported!(§e" + version + "§c). Please use version §e" + minVersion + " §cand above.");
             }
         }
     }

--- a/BuildBattleProCore/src/main/java/me/drawethree/buildbattle/leaderboards/BBLeaderboard.java
+++ b/BuildBattleProCore/src/main/java/me/drawethree/buildbattle/leaderboards/BBLeaderboard.java
@@ -6,11 +6,13 @@ import me.drawethree.buildbattle.BuildBattle;
 import me.drawethree.buildbattle.hooks.BBHook;
 import me.drawethree.buildbattle.objects.bbobjects.BBPlayerStats;
 import me.drawethree.buildbattle.objects.bbobjects.BBStat;
+import me.drawethree.buildbattle.objects.bbobjects.BBStatIntegerComparator;
 import me.drawethree.buildbattle.utils.LocationUtil;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.scheduler.BukkitRunnable;
 
+import java.util.Collections;
 import java.util.List;
 
 public class BBLeaderboard {
@@ -42,16 +44,17 @@ public class BBLeaderboard {
                 hologram.clearLines();
                 hologram.appendTextLine(ChatColor.translateAlternateColorCodes('&', getType().getTitle()));
 
-                /*switch (type) {
-                    case WINS:
-                    case PLAYED:
-                    case BLOCKS_PLACED:
-                    case PARTICLES_PLACED:
-                        Collections.sort(loadedStats, new BBStatIntegerComparator(BBStat.valueOf(type.name())).reversed());
-                        break;
-                    default:
-                        return;
-                }*/
+//                switch (type) {
+//                    case WINS:
+//                    case PLAYED:
+//                    case BLOCKS_PLACED:
+//                    case PARTICLES_PLACED:
+//                        loadedStats.sort(new BBStatIntegerComparator(BBStat.valueOf(type.name())).reversed());
+//                        break;
+//                    default:
+//                        return;
+//                }
+                loadedStats.sort(new BBStatIntegerComparator(BBStat.valueOf(type.name())).reversed());
 
                 for (int i = 0, position = 0; ; i++) {
 

--- a/BuildBattleProCore/src/main/java/me/drawethree/buildbattle/listeners/PlayerListener.java
+++ b/BuildBattleProCore/src/main/java/me/drawethree/buildbattle/listeners/PlayerListener.java
@@ -127,7 +127,7 @@ public class PlayerListener implements Listener {
         }
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onClick(InventoryClickEvent e) {
         Player p = (Player) e.getWhoClicked();
         Inventory clickedInventory = e.getClickedInventory();
@@ -587,9 +587,13 @@ public class PlayerListener implements Listener {
                     if (arenaSign != null) {
                         e.setCancelled(true);
                         arenaSign.handleClick(p, e.getAction());
+                        return;
                     }
                 }
             }
+
+            // Try spectate mode menu click
+            this.plugin.getSpectatorManager().onPlayerInterract(e);
         }
     }
 

--- a/BuildBattleProCore/src/main/java/me/drawethree/buildbattle/listeners/ServerListener.java
+++ b/BuildBattleProCore/src/main/java/me/drawethree/buildbattle/listeners/ServerListener.java
@@ -4,6 +4,7 @@ import me.drawethree.buildbattle.BuildBattle;
 import me.drawethree.buildbattle.objects.bbobjects.arena.BBArena;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockExplodeEvent;
 import org.bukkit.event.server.ServerListPingEvent;
 
 import java.util.ArrayList;
@@ -26,5 +27,10 @@ public class ServerListener implements Listener {
                 }
             }
         }
+    }
+
+    @EventHandler
+    public void onBlockExplode(BlockExplodeEvent event) {
+        event.setCancelled(true);
     }
 }

--- a/BuildBattleProCore/src/main/java/me/drawethree/buildbattle/managers/MySQLManager.java
+++ b/BuildBattleProCore/src/main/java/me/drawethree/buildbattle/managers/MySQLManager.java
@@ -197,7 +197,7 @@ public class MySQLManager {
 
     public List<BBPlayerStats> loadTopStatistics(BBStat stat, int amountToDisplay) {
         List<BBPlayerStats> returnList = new ArrayList<>();
-        ResultSet set = database.query("SELECT UUID," + stat.getSQLKey() + " FROM BuildBattlePro_PlayerData ORDER BY ? DESC LIMIT ?", stat.getSQLKey(), amountToDisplay);
+        ResultSet set = database.query("SELECT UUID," + stat.getSQLKey() + " FROM BuildBattlePro_PlayerData ORDER BY " + stat.getSQLKey() + " DESC LIMIT ?", amountToDisplay);
         while (true) {
             try {
                 if (!set.next()) break;

--- a/BuildBattleProCore/src/main/java/me/drawethree/spectateapi/Spectatable.java
+++ b/BuildBattleProCore/src/main/java/me/drawethree/spectateapi/Spectatable.java
@@ -6,13 +6,13 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public interface Spectatable<E extends Player> {
 
-    ItemStack QUIT_SPECTATE_ITEM = ItemUtil.create(CompMaterial.BARRIER, 1, "&cQuit Spectate", Arrays.asList(new String[]{"§7Click to quit spectating"}), null, null);
-    ItemStack SPECTATE_ITEM = ItemUtil.create(CompMaterial.COMPASS, 1, "&eSpectate", Arrays.asList(new String[]{"§7Click to open up spectate inventory"}), null, null);
+    ItemStack QUIT_SPECTATE_ITEM = ItemUtil.create(CompMaterial.BARRIER, 1, "&cQuit Spectate", Collections.singletonList("§7Click to quit spectating"), null, null);
+    ItemStack SPECTATE_ITEM = ItemUtil.create(CompMaterial.COMPASS, 1, "&eSpectate", Collections.singletonList("§7Click to open up spectate inventory"), null, null);
 
     Inventory getSpectateInventory();
 

--- a/BuildBattleProCore/src/main/java/me/drawethree/spectateapi/SpectatorManager.java
+++ b/BuildBattleProCore/src/main/java/me/drawethree/spectateapi/SpectatorManager.java
@@ -92,7 +92,7 @@ public class SpectatorManager implements Listener {
         this.handleEvent(e, p);
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    //@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPlayerInterract(PlayerInteractEvent e) {
         Player p = e.getPlayer();
         if (this.spectators.containsKey(p) && e.getItem() != null) {
@@ -160,11 +160,12 @@ public class SpectatorManager implements Listener {
 
         this.playerData.put(p, new SpectatePlayerData(p));
 
-        this.runPlayerSpectateCommands(p);
+        //this.runPlayerSpectateCommands(p);
 
         this.spectators.put(p, target);
 
-        target.spectate(p);
+        p.sendMessage("§aTeleportuji...");
+        Bukkit.getScheduler().runTaskLater(plugin, () -> target.spectate(p), 10);
     }
 
     private void runPlayerSpectateCommands(Player p) {


### PR DESCRIPTION
Fixed: HD leaderboards sorting, event priorities and cancellations, spectate mode sometimes did double teleport

Added: Disabled explosions (mainly because of Respawn anchor explosions in arena), Added FAWE (FastAsyncWorldedit) support